### PR TITLE
Add Visible Learning info card

### DIFF
--- a/assets/sass/components/_btn.scss
+++ b/assets/sass/components/_btn.scss
@@ -9,7 +9,6 @@
 
 	&--primary {
 		border: 2px solid #2D3142;
-		background-color: transparent;
 		padding: 1.25rem;
 
 		&:link,
@@ -25,5 +24,8 @@
 		}
 	}
 
-	&--special { }
+	&--platform {
+		display: inline-block;
+		margin-top: 2rem;
+	}
 }

--- a/assets/sass/layout/_platforms.scss
+++ b/assets/sass/layout/_platforms.scss
@@ -57,6 +57,7 @@
 	&__content {
 		background-color: rgba(7, 51, 47, 0.1);
 		padding: 4rem;
+		flex: 1;
 
 		@include respond(phone-xxl) { padding: 2rem; }
 	}

--- a/assets/sass/layout/_platforms.scss
+++ b/assets/sass/layout/_platforms.scss
@@ -14,7 +14,7 @@
 		display: flex;
 		flex-direction: column;
 
-		&:nth-child(-n+2) { margin-bottom: 3rem; }
+		&:not(:last-child) { margin-bottom: 3rem; }
 
 		@include respond(tab-port-lg) {
 			flex: 0 0 75%;

--- a/data/platforms.yaml
+++ b/data/platforms.yaml
@@ -13,6 +13,9 @@ project:
       Hinblick auf den Lehrplan 21 sichtbar zu machen und mit Weitsicht zu
       begleiten. Der gesamte Inhalt der Chinderzytig ist mit den Kompetenzen des
       Lehrplan 21 verknüpft und durch die Software aufbereitet.
+    btn:
+      - link: "https://www.chinderzytig.ch/visible-learning/"
+        label: "Mehr erfahren"
   - svg: "svgs/mana-zeitung.html"
     title: "Die Weiterentwicklung der Chinderzytig und der Jugendzytig"
     text: |

--- a/layouts/partials/platforms.html
+++ b/layouts/partials/platforms.html
@@ -21,7 +21,7 @@
 						<h3 class="heading heading__tertiary">{{ .title }}</h3>
 						<p class="platforms__text">{{ .text }}</p>
 						{{ range .btn }}
-							<a href="{{ .link }}" class="btn btn--primary btn--platform">{{ .label }}</a>
+							<a href="{{ .link }}" target="_blank" class="btn btn--primary btn--platform">{{ .label }}</a>
 						{{ end }}
 					</div>
 				</div>

--- a/layouts/partials/platforms.html
+++ b/layouts/partials/platforms.html
@@ -20,6 +20,9 @@
 					<div class="platforms__content">
 						<h3 class="heading heading__tertiary">{{ .title }}</h3>
 						<p class="platforms__text">{{ .text }}</p>
+						{{ range .btn }}
+							<a href="{{ .link }}" class="btn btn--primary btn--platform">{{ .label }}</a>
+						{{ end }}
 					</div>
 				</div>
 			{{ end }}


### PR DESCRIPTION
Added a Visible Learning information card to the platforms list section. Button links to: https://www.chinderzytig.ch/visible-learning/

<img width="1419" alt="CleanShot 2021-07-22 at 20 57 42@2x" src="https://user-images.githubusercontent.com/16960228/126694301-32fd704a-5a5e-4d96-adba-9cc30c2e010f.png">
