### PR TITLE
update Wikimedia logo

### DIFF
--- a/data/partners.yaml
+++ b/data/partners.yaml
@@ -23,7 +23,7 @@ companies:
   logo:
     - img: "PH-Bern-logo-white_c1n0f0.png"
       desc: "PH Bern logo"
-- website: "https://wikimediafoundation.org/"
+- website: "https://wikimedia.ch/de/"
   logo:
-    - img: "Wikimedia-white_yzbugg.png"
-      desc: "Wikimedia Foundation logo"
+    - img: "wiki_ch_white_fhcme6.png"
+      desc: "Wikimedia CH logo"


### PR DESCRIPTION
Updated Wikimedia logo on Mana homepage:

![CleanShot 2024-01-16 at 13 32 47](https://github.com/Chinderzytig/mana/assets/16960228/4b1a03b4-2203-412a-9820-0518c64176b7)
